### PR TITLE
Reduced interactions

### DIFF
--- a/Matlab/WaveVortexModel/@WaveVortexModel/CheckHermitian.m
+++ b/Matlab/WaveVortexModel/@WaveVortexModel/CheckHermitian.m
@@ -12,7 +12,7 @@ function A = CheckHermitian(A)
                 ii = mod(M-i+1, M) + 1;
                 jj = mod(N-j+1, N) + 1;
                 if A(i,j,k) ~= conj(A(ii,jj,k))
-                    error('(i,j,k)=(%d,%d,%d) is not conjugate with (%d,%d,%d)\n',i,j,k,ii,jj,k)
+                    fprintf('(i,j,k)=(%d,%d,%d) is not conjugate with (%d,%d,%d)\n',i,j,k,ii,jj,k)
                 end
             end
         end

--- a/Matlab/WaveVortexModel/@WaveVortexModel/MaskForAliasedModes.m
+++ b/Matlab/WaveVortexModel/@WaveVortexModel/MaskForAliasedModes.m
@@ -1,0 +1,20 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% Returns a 'mask' (matrices with 1s or 0s) indicating where aliased wave
+% modes are, assuming the 2/3 anti-aliasing rule for quadratic
+% interactions. The reality is that the vertical modes do not follow this
+% rule.
+%
+% Basic usage,
+% AntiAliasMask = wvm.MaskForAliasedModes();
+% will return a mask that contains 1 at the locations of modes that will
+% alias with a quadratic multiplication.
+function AntiAliasFilter = MaskForAliasedModes(self)
+
+[K,L,J] = ndgrid(self.k,self.l,self.j);
+Kh = sqrt(K.*K + L.*L);
+
+AntiAliasFilter = zeros(self.Nk,self.Nl,self.Nj);
+AntiAliasFilter(Kh > 2*max(abs(self.k))/3 | J > 2*max(abs(self.j))/3) = 1;
+
+end

--- a/Matlab/WaveVortexModel/@WaveVortexModel/WaveVortexModel.m
+++ b/Matlab/WaveVortexModel/@WaveVortexModel/WaveVortexModel.m
@@ -143,6 +143,7 @@ classdef WaveVortexModel < handle
 
             if self.shouldAntiAlias == 1
                 self.disallowNonlinearInteractionsWithAliasedModes();
+                self.freezeEnergyOfAliasedModes();
             end
         end
         
@@ -513,6 +514,16 @@ classdef WaveVortexModel < handle
             self.EMA0 = self.EMA0 & ~AntiAliasMask;
             self.EMAm = self.EMAm & ~AntiAliasMask;
             self.EMAp = self.EMAp & ~AntiAliasMask;
+        end
+
+        function clearEnergyOfAliasedModes(self)
+            % In addition to disallowing interaction to occur between modes
+            % that are aliased, you may actually want to disallow energy to
+            % even enter the aliased modes.
+            AntiAliasMask = self.MaskForAliasedModes();
+            self.A0 = self.A0 .* ~AntiAliasMask;
+            self.Am = self.Am .* ~AntiAliasMask;
+            self.Ap = self.Ap .* ~AntiAliasMask;
         end
 
 

--- a/Matlab/WaveVortexModel/@WaveVortexModelHydrostatic/WaveVortexModelHydrostatic.m
+++ b/Matlab/WaveVortexModel/@WaveVortexModelHydrostatic/WaveVortexModelHydrostatic.m
@@ -245,7 +245,12 @@ classdef WaveVortexModelHydrostatic < WaveVortexModel
         function w = TransformToSpatialDomainWithG(self, w_bar )
             % hydrostatic modes commute with the DFT
             w_bar = ifft(ifft(w_bar,self.Nx,1),self.Ny,2,'symmetric');
-
+            
+            w_bar = permute(w_bar,[3 1 2]); % keep adjacent in memory
+            w_bar = reshape(w_bar,self.nModes,[]);
+            w = self.QGinv*w_bar;
+            w = reshape(w,self.Nz,self.Nx,self.Ny);
+            w = permute(w,[2 3 1]);
         end
         
         function [u,ux,uy,uz] = TransformToSpatialDomainWithFAllDerivatives(self, u_bar)

--- a/Matlab/WaveVortexModel/Example/CyprusEddy/CyprusEddy.m
+++ b/Matlab/WaveVortexModel/Example/CyprusEddy/CyprusEddy.m
@@ -13,7 +13,7 @@ inertialPeriod = (2*pi/(2 * 7.2921E-5 * sin( latitude*pi/180 )));
 maxTime = 2*inertialPeriod;
 outputInterval = inertialPeriod/10;
 
-outputfile = '/Volumes/MoreStorage/Data/cyprus_eddy_wvm/cyprus_eddy-more-stratification-strong.nc';
+outputfile = '/Volumes/MoreStorage/Data/cyprus_eddy_wvm/cyprus_eddy-more-stratification-strong-2.nc';
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %

--- a/Matlab/WaveVortexModel/Example/CyprusEddy/ShowNonlinearFluxesFourPanel.m
+++ b/Matlab/WaveVortexModel/Example/CyprusEddy/ShowNonlinearFluxesFourPanel.m
@@ -2,7 +2,7 @@
 scaleFactor = 1;
 LoadFigureDefaults
 
-file = '/Volumes/MoreStorage/Data/cyprus_eddy_wvm/cyprus_eddy-more-stratification-strong.nc';
+file = '/Volumes/MoreStorage/Data/cyprus_eddy_wvm/cyprus_eddy-more-stratification-strong-2.nc';
 
 % load('NonlinearFluxes.mat');
 energies.t = ncread(file,'t');

--- a/Matlab/WaveVortexModel/UnitTests/ProfileableSpeedTest.m
+++ b/Matlab/WaveVortexModel/UnitTests/ProfileableSpeedTest.m
@@ -63,11 +63,19 @@ Ubar = wvm.UAp.*Ap + wvm.UAm.*Am + wvm.UA0.*A0;
 % end
 % profile viewer
 
-profile on
-for i=1:5
-
-Fp = wvm.TransformToSpatialDomainWithF(Ubar);
-% [Fp,Fm,F0] = wvm.NonlinearFluxAtTime(10,Ap,Am,A0);
+% profile on
+tic
+for i=1:15
+[Fp,Fm,F0] = wvm.NonlinearFluxAtTimeNoMask(10,Ap,Am,A0);
 end
-profile viewer
+toc
+
+tic
+for i=1:15
+[Fp,Fm,F0] = wvm.NonlinearFluxAtTime(10,Ap,Am,A0);
+end
+toc
+
+
+% profile viewer
 


### PR DESCRIPTION
This adds a number of new functions designed to,

1. disallow nonlinear interactions with specified modes,
2. freeze energy content of specified modes

These changes are *mostly* additive and shouldn't break any existing code. However, one thing to check is anti-aliasing. I turned anti-aliasing back on by default, however, it is now only every used when calling -NonlinearFluxAtTime. In theory, this won't break any of the diagnostic uses of the code.